### PR TITLE
Bump to Jekyll 3.x and HTML Pipeline 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
+- 2.2
 - 2.1
 - 2.0
-- 1.9.3
 script: script/cibuild
 sudo: false
 cache: bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem 'html-pipeline', github: "benbalter/html-pipeline", branch: "mention-link-filter-arg-fix"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
 gemspec
-
-gem 'html-pipeline', github: "benbalter/html-pipeline", branch: "mention-link-filter-arg-fix"

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
   s.add_dependency "jekyll", '~> 3.0'
-  s.add_dependency "html-pipeline", '~> 2.2'
+  s.add_dependency "html-pipeline", '~> 2.2.2'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
   s.add_dependency "jekyll", '~> 3.0'
-  s.add_dependency "html-pipeline", '~> 2.2.2'
+  s.add_dependency "html-pipeline", '~> 2.2'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
-  s.add_dependency "jekyll", '~> 2.0'
-  s.add_dependency "html-pipeline", '~> 1.9.0'
+  s.add_dependency "jekyll", '~> 3.0'
+  s.add_dependency "html-pipeline", '~> 2.2'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -19,7 +19,8 @@ module Jekyll
 
     def mentionify(page)
       return unless page.content.include?('@')
-      page.content = @filter.mention_link_filter(page.content)
+      # see https://github.com/jekyll/jekyll-mentions/pull/22 if you're wondering about the nils
+      page.content = @filter.mention_link_filter(page.content, nil, nil, nil)
     end
 
     def html_page?(page)

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -20,7 +20,7 @@ module Jekyll
     def mentionify(page)
       return unless page.content.include?('@')
       # see https://github.com/jekyll/jekyll-mentions/pull/22 if you're wondering about the nils
-      page.content = @filter.mention_link_filter(page.content, nil, nil, nil)
+      page.content = @filter.mention_link_filter(page.content, nil, nil, HTML::Pipeline::MentionFilter::UsernamePattern)
     end
 
     def html_page?(page)

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -13,7 +13,7 @@ module Jekyll
 
     def generate(site)
       site.pages.each { |page| mentionify page if html_page?(page) }
-      site.posts.each { |post| mentionify post }
+      site.posts.docs.each { |post| mentionify post }
       site.docs_to_write.each { |doc| mentionify doc }
     end
 


### PR DESCRIPTION
Do we want to maintain support for Jekyll 2.x? I'm fine only supporting Jekyll 3.x assuming GitHub Pages can make the jump.