### PR TITLE
Allow users still on 2.5 to continue to use this gem.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,22 @@
 language: ruby
 rvm:
-- 2.2
-- 2.1
 - 2.0
+- 2.1
+- 2.2
 script: script/cibuild
 sudo: false
 cache: bundler
 env:
-  global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  global: NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+  - JEKYLL_VERSION=2.5
+  - JEKYLL_VERSION=3.0
 notifications:
   irc:
     on_success: change
     on_failure: change
-    channels:
-    - irc.freenode.org#jekyll
-    template:
-    - '%{repository}#%{build_number} (%{branch}) %{message} %{build_url}'
+    channels: irc.freenode.org#jekyll
+    template: '%{repository}#%{build_number} (%{branch}) %{message} %{build_url}'
   email:
     on_success: never
     on_failure: never

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
-
 gemspec
+
+if ENV["JEKYLL_VERSION"]
+  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
+end

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
-  s.add_dependency "jekyll", '~> 3.0'
+  s.add_dependency "jekyll", '>= 2.5', '< 4.0'
   s.add_dependency "html-pipeline", '~> 2.2'
 
   s.add_development_dependency  'rake'


### PR DESCRIPTION
The last update that enforced 3.0 broke the requirement of jekyll/docker to be able to hold one revision back for users who are slow to update as per our new and requested Jekyll Docker policy. 

/cc jekyll/docker#61
/cc @benbalter @parkr 