### PR TITLE
Don't double convert @mentions in posts in Jekyll > 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 bin
 /*.gem
 Gemfile.lock
+/tmp

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
   s.add_dependency "jekyll", '~> 3.0'
-  s.add_dependency "html-pipeline", '~> 2.2'
+  s.add_dependency "html-pipeline", '~> 2.3'
 
   s.add_development_dependency  'rake'
   s.add_development_dependency  'rdoc'

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -13,14 +13,12 @@ module Jekyll
 
     def generate(site)
       site.pages.each { |page| mentionify page if html_page?(page) }
-      site.posts.docs.each { |post| mentionify post }
       site.docs_to_write.each { |doc| mentionify doc }
     end
 
     def mentionify(page)
       return unless page.content.include?('@')
-      # see https://github.com/jekyll/jekyll-mentions/pull/22 if you're wondering about the nils
-      page.content = @filter.mention_link_filter(page.content, nil, nil, HTML::Pipeline::MentionFilter::UsernamePattern)
+      page.content = @filter.mention_link_filter(page.content)
     end
 
     def html_page?(page)

--- a/test/fixtures/_config.yml
+++ b/test/fixtures/_config.yml
@@ -1,0 +1,3 @@
+collections:
+  docs:
+    output: true

--- a/test/fixtures/_posts/2016-01-01-awesome-post.md
+++ b/test/fixtures/_posts/2016-01-01-awesome-post.md
@@ -1,0 +1,5 @@
+---
+title: I'm a post
+---
+
+test @test test

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,7 +19,9 @@ module MentionsTestHelpers
           "source" => FIXTURES_DIR,
           "destination" => DEST_DIR,
           "collections" => {
-            "docs"  => {}
+            "docs"  => {
+              "output" => true
+            }
           }
         }
       )

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,24 +8,18 @@ require 'jekyll-mentions'
 
 TEST_DIR     = File.expand_path("../", __FILE__)
 FIXTURES_DIR = File.expand_path("fixtures", TEST_DIR)
-DEST_DIR     = File.expand_path("destination", TEST_DIR)
+DEST_DIR     = File.expand_path("../tmp/destination", TEST_DIR)
 
 module MentionsTestHelpers
+  def config
+    @config ||= Jekyll.configuration({
+      "source" => FIXTURES_DIR,
+      "destination" => DEST_DIR
+    })
+  end
+
   def fixture_site
-    Jekyll::Site.new(
-      Jekyll::Utils.deep_merge_hashes(
-        Jekyll::Configuration::DEFAULTS,
-        {
-          "source" => FIXTURES_DIR,
-          "destination" => DEST_DIR,
-          "collections" => {
-            "docs"  => {
-              "output" => true
-            }
-          }
-        }
-      )
-    )
+    @site ||= Jekyll::Site.new(config)
   end
 
   def page_with_name(site, name)

--- a/test/test_jekyll_mentions.rb
+++ b/test/test_jekyll_mentions.rb
@@ -24,9 +24,21 @@ class TestJekyllMentions < Minitest::Test
     assert_equal @mention, page.content
   end
 
-  should "replace page content on generate" do
-    @mentions.generate(@site)
-    assert_equal @mention, @site.pages.first.content
+  context "generating" do
+    should "replace page content on generate" do
+      @mentions.generate(@site)
+      assert_equal @mention, @site.pages.first.content
+    end
+
+    should "replace post content on generate" do
+      @mentions.generate(@site)
+      assert_equal @mention, @site.posts.docs.first.content.strip
+    end
+
+    should "replace doc content on generate" do
+      @mentions.generate(@site)
+      assert_equal @mention, @site.collections["docs"].docs.first.content
+    end
   end
 
   should "not mangle liquid templating" do


### PR DESCRIPTION
In Jekyll > 3, posts are documents, so converting documents should convert all posts. There is no need to convert posts separately. Doing so, would double-convert the posts.

In tracking down this bug, I realized we didn't test generating posts or documents, and weren't properly generating the fixture site configuration. This fixes that.