### PR TITLE
Handle subclassing of Jekyll::Page

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -62,7 +62,7 @@ module Jekyll
       #
       # Returns true if the doc is written & is HTML.
       def mentionable?(doc)
-        (doc.class == Jekyll::Page || doc.write?) &&
+        (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
       end
     end


### PR DESCRIPTION
jekyll-sitemap, for example, uses a subclass. This will fix compatibility with that plugin.

/cc @jekyll/gh-pages