### PR TITLE
Don't strip html, body, and head tags

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -9,8 +9,16 @@ module Jekyll
 
     class << self
       def mentionify(doc)
+        return unless doc.output.include?("@")
         src = mention_base(doc.site.config)
-        doc.output = filter_with_mention(src).call(doc.output)[:output].to_s
+        if doc.output =~ /<\s*body/
+          parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
+          body          = parsed_doc.at_css('body')
+          body.children = filter_with_mention(src).call(body.inner_html)[:output].to_s
+          doc.output    = parsed_doc.to_html
+        else
+          doc.output = filter_with_mention(src).call(doc.output)[:output].to_s
+        end
       end
 
       # Public: Create or fetch the filter for the given {{src}} base URL.

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -4,6 +4,8 @@ require 'html/pipeline'
 module Jekyll
   class Mentions
     GITHUB_DOT_COM = "https://github.com".freeze
+    BODY_START_TAG = "<body".freeze
+
 
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
 
@@ -11,7 +13,7 @@ module Jekyll
       def mentionify(doc)
         return unless doc.output.include?("@")
         src = mention_base(doc.site.config)
-        if doc.output =~ /<\s*body/
+        if doc.output.include? BODY_START_TAG
           parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
           body          = parsed_doc.at_css('body')
           body.children = filter_with_mention(src).call(body.inner_html)[:output].to_s

--- a/spec/fixtures/_layouts/default.html
+++ b/spec/fixtures/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <title>{{ page.title }}</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="/css/screen.css">
+  </head>
+  <body class="wrap">
+    {{ content }}
+  </body>
+</html>

--- a/spec/fixtures/index.md
+++ b/spec/fixtures/index.md
@@ -1,4 +1,5 @@
 ---
+layout: default
 title: I'm a page
 ---
 

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -56,11 +56,16 @@ RSpec.describe(Jekyll::Mentions) do
     expect(complex_post.output).to include(result)
   end
 
-  it "correctly replaces the mentions with the img in pages" do
-    expect(site.pages.first.output).to start_with(para(result))
+  it "correctly replaces the mentions with the link in pages" do
+    expect(site.pages.first.output).to include(para(result))
   end
 
-  it "correctly replaces the mentions with the img in collection documents" do
+  it "doesn't mangle layouts" do
+    expect(site.pages.first.output).to include("<html lang=\"en-US\">")
+    expect(site.pages.first.output).to include("<body class=\"wrap\">\n")
+  end
+
+  it "correctly replaces the mentions with the link in collection documents" do
     expect(basic_doc.output).to start_with(para(result))
   end
 


### PR DESCRIPTION
Pulling in changes from https://github.com/jekyll/jemoji/pull/37 as well as some fixes of my own.

/cc @jekyll/gh-pages