### PR TITLE
Look to GitHub Metadata for mention URL base

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -6,7 +6,6 @@ module Jekyll
     GITHUB_DOT_COM = "https://github.com".freeze
     BODY_START_TAG = "<body".freeze
 
-
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
 
     class << self
@@ -58,7 +57,7 @@ module Jekyll
         mention_config = config['jekyll-mentions']
         case mention_config
         when nil, NilClass
-          GITHUB_DOT_COM
+          default_mention_base(config)
         when String
           mention_config.to_s
         when Hash
@@ -78,6 +77,16 @@ module Jekyll
       def mentionable?(doc)
         (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
+      end
+
+      private
+
+      def default_mention_base(config)
+        if config["github"] && config["github"]["mention_url_base"]
+          config["github"]["mention_url_base"]
+        else
+          GITHUB_DOT_COM
+        end
       end
     end
   end

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -95,4 +95,21 @@ RSpec.describe(Jekyll::Mentions) do
       expect(basic_post.output).to start_with(para(result.sub(default_src, mentions_src)))
     end
   end
+
+  context "when pulling the base from github metadata" do
+    let(:mentions_src) { "https://example.com" }
+    let(:config_overrides) do
+      {
+        "github" => { "mention_url_base" => mentions_src }
+      }
+    end
+
+    it "fetches the custom base from the config" do
+      expect(mentions.mention_base(site.config)).to eql(mentions_src)
+    end
+
+    it "respects the new base when mentionsfying" do
+      expect(basic_post.output).to start_with(para(result.sub(default_src, mentions_src)))
+    end
+  end
 end


### PR DESCRIPTION
* Blocked by https://github.com/jekyll/github-metadata/pull/65.
* Fixes https://github.com/jekyll/jekyll-mentions/issues/34.

This pull request looks to `site.github.mention_url_base` as the default mention base URL, when set (and continues to fall back to `https://github.com` when not present).