### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-mentions.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
-require 'rubygems'
-require 'bundler'
+require "rubygems"
+require "bundler"
 begin
   Bundler.setup(:default, :development, :test)
 rescue Bundler::BundlerError => e
@@ -7,12 +7,12 @@ rescue Bundler::BundlerError => e
   $stderr.puts "Run `bundle install` to install missing gems"
   exit e.status_code
 end
-require 'bundler/gem_tasks'
-require 'rake'
-require 'rake/testtask'
+require "bundler/gem_tasks"
+require "rake"
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
+  test.libs << "lib" << "test"
+  test.pattern = "test/**/test_*.rb"
   test.verbose = true
 end

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -9,10 +9,10 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = [ "lib/jekyll-mentions.rb" ]
 
-  s.add_dependency "jekyll", '~> 3.0'
-  s.add_dependency "html-pipeline", '~> 2.3'
+  s.add_dependency "jekyll", "~> 3.0"
+  s.add_dependency "html-pipeline", "~> 2.3"
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rdoc"
+  s.add_development_dependency "rspec", "~> 3.0"
 end

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "jekyll", "~> 3.0"
   s.add_dependency "html-pipeline", "~> 2.3"
+  s.add_dependency "activesupport", "~> 4.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rdoc"

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -34,8 +34,10 @@ module Jekyll
       end
 
       def mention_username_pattern
-        Regexp.new(HTML::Pipeline::MentionFilter::UsernamePattern.source,
-        Regexp::IGNORECASE)
+        Regexp.new(
+          HTML::Pipeline::MentionFilter::UsernamePattern.source,
+          Regexp::IGNORECASE
+        )
       end
 
       # Public: Filters hash where the key is the mention base URL.

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -9,6 +9,7 @@ module Jekyll
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
 
     class << self
+      # rubocop:disable Metrics/AbcSize
       def mentionify(doc)
         return unless doc.output.include?("@")
         src = mention_base(doc.site.config)

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -1,11 +1,10 @@
-require 'jekyll'
-require 'html/pipeline'
+require "jekyll"
+require "html/pipeline"
 
 module Jekyll
   class Mentions
     GITHUB_DOT_COM = "https://github.com".freeze
     BODY_START_TAG = "<body".freeze
-
 
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
 
@@ -15,7 +14,7 @@ module Jekyll
         src = mention_base(doc.site.config)
         if doc.output.include? BODY_START_TAG
           parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
-          body          = parsed_doc.at_css('body')
+          body          = parsed_doc.at_css("body")
           body.children = filter_with_mention(src).call(body.inner_html)[:output].to_s
           doc.output    = parsed_doc.to_html
         else
@@ -31,11 +30,12 @@ module Jekyll
       def filter_with_mention(src)
         filters[src] ||= HTML::Pipeline.new([
           HTML::Pipeline::MentionFilter
-        ], { :base_url => src , :username_pattern => mention_username_pattern })
+        ], { :base_url => src, :username_pattern => mention_username_pattern })
       end
 
       def mention_username_pattern
-        Regexp.new(HTML::Pipeline::MentionFilter::UsernamePattern.source, Regexp::IGNORECASE)
+        Regexp.new(HTML::Pipeline::MentionFilter::UsernamePattern.source,
+        Regexp::IGNORECASE)
       end
 
       # Public: Filters hash where the key is the mention base URL.
@@ -55,14 +55,14 @@ module Jekyll
       # Returns a URL to use as the base URL for mentions.
       # Defaults to the https://github.com.
       def mention_base(config = {})
-        mention_config = config['jekyll-mentions']
+        mention_config = config["jekyll-mentions"]
         case mention_config
         when nil, NilClass
           GITHUB_DOT_COM
         when String
           mention_config.to_s
         when Hash
-          mention_config.fetch('base_url', GITHUB_DOT_COM)
+          mention_config.fetch("base_url", GITHUB_DOT_COM)
         else
           raise InvalidJekyllMentionConfig,
             "Your jekyll-mentions config has to either be a" \

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe(Jekyll::Mentions) do
   Jekyll.logger.log_level = :error
@@ -6,10 +6,10 @@ RSpec.describe(Jekyll::Mentions) do
   let(:config_overrides) { {} }
   let(:configs) do
     Jekyll.configuration(config_overrides.merge({
-      'skip_config_files' => false,
-      'collections'       => { 'docs' => { 'output' => true } },
-      'source'            => fixtures_dir,
-      'destination'       => fixtures_dir('_site')
+      "skip_config_files" => false,
+      "collections"       => { "docs" => { "output" => true } },
+      "source"            => fixtures_dir,
+      "destination"       => fixtures_dir("_site")
     }))
   end
   let(:mentions)    { described_class }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
-require File.expand_path('../../lib/jekyll-mentions.rb', __FILE__)
+require File.expand_path("../../lib/jekyll-mentions.rb", __FILE__)
 
 RSpec.configure do |config|
-  FIXTURES_DIR = File.expand_path('../fixtures', __FILE__)
+  FIXTURES_DIR = File.expand_path("../fixtures", __FILE__)
   def fixtures_dir(*paths)
     File.join(FIXTURES_DIR, *paths)
   end


### PR DESCRIPTION
Based on https://github.com/jekyll/jekyll-seo-tag/pull/109

This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml `to` .rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.

Note, that this PR does not fix the last offense:

`lib/jekyll-mentions.rb:12:7: C: Assignment Branch Condition size for mentionify is too high. [21.93/20]
      def mentionify(doc)`