### PR TITLE
Add support for building the base URL from ENV on Enterprise

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -61,11 +61,11 @@ module Jekyll
         mention_config = config["jekyll-mentions"]
         case mention_config
         when nil, NilClass
-          GITHUB_DOT_COM
+          default_mention_base
         when String
           mention_config.to_s
         when Hash
-          mention_config.fetch("base_url", GITHUB_DOT_COM)
+          mention_config.fetch("base_url", default_mention_base)
         else
           raise InvalidJekyllMentionConfig,
             "Your jekyll-mentions config has to either be a" \
@@ -81,6 +81,17 @@ module Jekyll
       def mentionable?(doc)
         (doc.is_a?(Jekyll::Page) || doc.write?) &&
           doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
+      end
+
+      private
+
+      def default_mention_base
+        if !ENV["SSL"].to_s.empty? && !ENV["GITHUB_HOSTNAME"].to_s.empty?
+          scheme = ENV["SSL"] == "true" ? "https://" : "http://"
+          "#{scheme}#{ENV["GITHUB_HOSTNAME"].chomp("/")}"
+        else
+          GITHUB_DOT_COM
+        end
       end
     end
   end

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -95,4 +95,40 @@ RSpec.describe(Jekyll::Mentions) do
       expect(basic_post.output).to start_with(para(result.sub(default_src, mentions_src)))
     end
   end
+
+  context "with the SSL and GITHUB_HOSTNAME environment variables set" do
+    let(:ssl)                  { "true" }
+    let(:github_hostname)      { "github.vm" }
+    let(:default_mention_base) { "https://github.vm" }
+
+    before(:each) do
+      ENV["SSL"] = ssl
+      ENV["GITHUB_HOSTNAME"] = github_hostname
+    end
+
+    after(:each) do
+      ENV.delete("SSL")
+      ENV.delete("GITHUB_HOSTNAME")
+    end
+
+    it "has a default source based on SSL and GITHUB_HOSTNAME" do
+      expect(mentions.mention_base).to eql(default_mention_base)
+    end
+
+    it "uses correct mention URLs when SSL and GITHUB_HOSTNAME are set" do
+      # Re-render the site, so that ENV is used
+      site.render
+      expect(basic_post.output).to start_with(para(result.sub(default_src, default_mention_base)))
+    end
+
+    it "falls back to using the default if SSL is empty" do
+      ENV["SSL"] = ""
+      expect(mentions.mention_base).to eql(default_src)
+    end
+
+    it "falls back to using the default if GITHUB_HOSTNAME is empty" do
+      ENV["GITHUB_HOSTNAME"] = ""
+      expect(mentions.mention_base).to eql(default_src)
+    end
+  end
 end


### PR DESCRIPTION
This is an alternative to https://github.com/jekyll/jekyll-mentions/pull/35 and https://github.com/jekyll/github-metadata/pull/65, and fixes https://github.com/jekyll/jekyll-mentions/issues/34.

In a GitHub Enterprise environment, the `SSL` and `GITHUB_HOSTNAME` environment variables are available to the page build process, meaning they can be used to correctly build the base URL for mentions when this plugin is used, instead of `https://github.com` being incorrectly used by default.

Similar to https://github.com/jekyll/jemoji/pull/45.

@benbalter, @parkr: Could you take a look?