### PR TITLE
Allow underscores in usernames

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -38,10 +38,7 @@ module Jekyll
       end
 
       def mention_username_pattern
-        Regexp.new(
-          HTML::Pipeline::MentionFilter::UsernamePattern.source,
-          Regexp::IGNORECASE
-        )
+        @mention_username_pattern ||= %r![\w][\w_-]*!
       end
 
       # Public: Filters hash where the key is the mention base URL.

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -38,7 +38,7 @@ module Jekyll
       end
 
       def mention_username_pattern
-        @mention_username_pattern ||= %r![\w][\w_-]*!
+        @mention_username_pattern ||= %r![\w][\w-]*!
       end
 
       # Public: Filters hash where the key is the mention base URL.

--- a/spec/fixtures/_docs/special_characters.md
+++ b/spec/fixtures/_docs/special_characters.md
@@ -1,0 +1,11 @@
+---
+title: Unconventional Names
+---
+
+Howdy @-pardner!
+
+@haTTric- sez you are quite the @task-master..
+
+Checkout @Casino_Royale
+
+The Original @_Bat_Cave

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe(Jekyll::Mentions) do
   let(:basic_doc) { find_by_title(site.collections["docs"].docs, "File") }
   let(:doc_with_liquid) { find_by_title(site.collections["docs"].docs, "With Liquid") }
   let(:txt_doc) { find_by_title(site.collections["docs"].docs, "Don't Touch Me") }
+  let(:spl_chars_doc) { find_by_title(site.collections["docs"].docs, "Unconventional Names") }
 
   def para(content)
     "<p>#{content}</p>"
@@ -77,6 +78,28 @@ RSpec.describe(Jekyll::Mentions) do
     expect(doc_with_liquid.output).to start_with(
       para("#{result} <a href=\"/docs/with_liquid.html\">_docs/with_liquid.md</a>")
     )
+  end
+
+  context "with non-word characters" do
+    it "does not render when there's a leading hyphen" do
+      expect(spl_chars_doc.output).to start_with(para("Howdy @-pardner!"))
+    end
+
+    it "renders fine when there's a non-leading hyphen" do
+      expect(spl_chars_doc.output).to include(para(
+        "<a href=\"https://github.com/haTTric-\" class=\"user-mention\">@haTTric-</a> sez you are quite " \
+        "the <a href=\"https://github.com/task-master\" class=\"user-mention\">@task-master</a>.."
+      ))
+    end
+
+    it "renders fine when there's an underscore" do
+      expect(spl_chars_doc.output).to include(para(
+        "Checkout <a href=\"https://github.com/Casino_Royale\" class=\"user-mention\">@Casino_Royale</a>"
+      ))
+      expect(spl_chars_doc.output).to include(para(
+        "The Original <a href=\"https://github.com/_Bat_Cave\" class=\"user-mention\">@_Bat_Cave</a>"
+      ))
+    end
   end
 
   context "with a different base for jmentions" do


### PR DESCRIPTION
Change the regex in `:mention_username_pattern` directly in this plugin as the only non-word character whitelisted in GitHub usernames seems to be the hyphen `-` based on [currently used regex](https://github.com/jch/html-pipeline/blob/cdb943678efc905ec542487f33413e0ba0d322f3/lib/html/pipeline/%40mention_filter.rb#L56)

Resolves #24 
Resolves #45 