### PR TITLE
Fix entries to History.markdown

### DIFF
--- a/History.markdown
+++ b/History.markdown
@@ -1,16 +1,16 @@
 ## HEAD
 
-  * Release 1.3.0 ### -minor (#58)
-  * Rubocop 0.55 (#61)
-
 ### Minor Enhancements
 
-  * Drop support for Ruby 2.2.x (#60)
+  * Bump Rubocop to 0.55 (#61)
+  * Drop support for Ruby 2.2.x (#61)
+  * Relax version constraint on ActiveSupport (#60)
 
 ## 1.3.0 / 2018-03-14
 
 ### Development Fixes
 
+  * Release 1.3.0 (#58)
   * Add rubocop to script/cibuild (#44)
   * Rubocop: autocorrect (#49)
   * Define path with __dir__ (#46)


### PR DESCRIPTION
IMO, this should be manually merged so that JekyllBot doesn't record this in the History document..