### PR TITLE
Reintroduce style checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,17 @@
+require: rubocop-jekyll
 inherit_gem:
-  jekyll: .rubocop.yml
+  rubocop-jekyll: .rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
+Layout/FirstParameterIndentation:
+  Exclude:
+    - spec/**/*
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -43,7 +43,7 @@ module Jekyll
       def filter_with_mention(src)
         filters[src] ||= HTML::Pipeline.new([
           HTML::Pipeline::MentionFilter,
-        ], { :base_url => src, :username_pattern => mention_username_pattern })
+        ], :base_url => src, :username_pattern => mention_username_pattern)
       end
 
       def mention_username_pattern
@@ -77,8 +77,8 @@ module Jekyll
           mention_config.fetch("base_url", default_mention_base)
         else
           raise InvalidJekyllMentionConfig,
-            "Your jekyll-mentions config has to either be a" \
-            " string or a hash. It's a #{mention_config.class} right now."
+                "Your jekyll-mentions config has to either be a string or a hash. " \
+                "It's a #{mention_config.class} right now."
         end
       end
 
@@ -117,6 +117,6 @@ module Jekyll
   end
 end
 
-Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
   Jekyll::Mentions.mentionify(doc) if Jekyll::Mentions.mentionable?(doc)
 end

--- a/script/cibuild
+++ b/script/cibuild
@@ -3,4 +3,5 @@
 set -e
 
 script/test
+script/fmt
 bundle exec rake build

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -5,12 +5,14 @@ RSpec.describe(Jekyll::Mentions) do
 
   let(:config_overrides) { {} }
   let(:configs) do
-    Jekyll.configuration(config_overrides.merge({
-      "skip_config_files" => false,
-      "collections"       => { "docs" => { "output" => true } },
-      "source"            => fixtures_dir,
-      "destination"       => fixtures_dir("_site"),
-    }))
+    Jekyll.configuration(
+      config_overrides.merge(
+        "skip_config_files" => false,
+        "collections"       => { "docs" => { "output" => true } },
+        "source"            => fixtures_dir,
+        "destination"       => fixtures_dir("_site")
+      )
+    )
   end
   let(:mentions)    { described_class }
   let(:default_src) { "https://github.com" }


### PR DESCRIPTION
- RuboCop failed earlier because the `master` branch did not inherit `config` from `rubocop-jekyll`
- Additional exclusions for spec files