### PR TITLE
Re-introduce Ruby 2.3 support and test with Jekyll 3.7 and beyond

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,6 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
   Exclude:
     - vendor/**/*
 Layout/FirstParameterIndentation:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.6
+- &latest_ruby 2.6
 - 2.4
+- 2.3
 
 before_install:
 - gem update --system
@@ -13,6 +14,18 @@ script: script/cibuild
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+  - JEKYLL_VERSION="~> 3.8"
+
+matrix:
+  include:
+  # GitHub Pages
+  - rvm: 2.5.3
+    env:
+    - JEKYLL_VERSION="~> 3.7.4"
+    - GITHUB_PAGES=1 # Only set on one build in matrix
+  - rvm: *latest_ruby
+    env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 
 notifications:
   irc:

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}" if ENV["JEKYLL_VERSION"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-mentions.gemspec
+++ b/jekyll-mentions.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.licenses    = ["MIT"]
   s.files       = ["lib/jekyll-mentions.rb"]
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.3.0"
 
   s.add_dependency "html-pipeline", "~> 2.3"
   s.add_dependency "jekyll", ">= 3.7", "< 5.0"


### PR DESCRIPTION
We're not using any Ruby 2.4 specific syntax and therefore can safely relax Ruby version support to the lowest Ruby version compatible across the ecosystem: Ruby 2.3