### PR TITLE
Support handling body tag across multiple lines

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -8,7 +8,7 @@ module Jekyll
     GITHUB_DOT_COM = "https://github.com"
     BODY_START_TAG = "<body"
 
-    OPENING_BODY_TAG_REGEX = %r!<body(.*?)>\s*!.freeze
+    OPENING_BODY_TAG_REGEX = %r!<body(.*?)>\s*!m.freeze
 
     InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
 

--- a/spec/fixtures/_layouts/multiline_body_tag.html
+++ b/spec/fixtures/_layouts/multiline_body_tag.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8">
+    <title>{{ page.title }}</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <link rel="stylesheet" href="/css/screen.css">
+  </head>
+  <body
+    class="wrap"
+  >
+    {{ content }}
+  </body>
+</html>

--- a/spec/fixtures/multiline-body-tag.md
+++ b/spec/fixtures/multiline-body-tag.md
@@ -1,0 +1,6 @@
+---
+layout: multiline_body_tag
+title: Multi-line Body Tag
+---
+
+test @TestUser test

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe(Jekyll::Mentions) do
     )
   end
 
+  it "works with HTML body tag markup across multiple lines" do
+    expect(find_by_title(site.pages, "Multi-line Body Tag").output).to include(para(result))
+  end
+
   context "with non-word characters" do
     it "does not render when there's a leading hyphen" do
       expect(spl_chars_doc.output).to start_with(para("Howdy @-pardner!"))


### PR DESCRIPTION
The counterpart patch of https://github.com/jekyll/jemoji/pull/96 for this plugin.