### PR TITLE
Allow configuring base URL in page front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Et voilà! Your mentions will now use that base URL instead of the default of `h
 
 ### Within a page's front matter
 
-Now do you want to override the base URL for just a single page/post? No problem. Just set the base URL for that specific page in the frontmatter:
+Now do you want to override the base URL for just a single page/post? No problem. Just set the base URL for that specific page in the front matter:
 
 ```yaml
 jekyll-mentions:
@@ -89,7 +89,7 @@ If you wish to change the base URL for a single mention, but not every mentions 
 [@benbalter](https://instagram.com/benbalter)
 ```
 
-Now, let's say you have a single file where you _don't_ want your mentions to become mentionable, AKA you want that to stay plain text. You can do that by specifying `false` in the frontmatter of that file:
+Now, let's say you have a single file where you _don't_ want your mentions to become mentionable, AKA you want that to stay plain text. You can do that by specifying `false` in the front matter of that file:
 
 ```yaml
 jekyll-mentions: false

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jekyll-mentions: https://facebook.com
 
 Now, every single mentions in the site will use the base URL defined in the `_config.yml`, EXCEPT in the file where you set the base URL to be something different.
 
-If you wish to change the base URL for a single mentions in a file, but not every mentions in that file, then you'll have to link to the URL the old-fashioned way:
+If you wish to change the base URL for a single mention, but not every mentions in that file, then you'll have to link to the URL the old-fashioned way:
 
 ```markdown
 [@benbalter](https://instagram.com/benbalter)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ If you're lazy like me, you can use this shorthand:
 jekyll-mentions: https://facebook.com
 ```
 
-Now, every single mentions in the site will use the base URL defined in the `_config.yml`, EXCEPT in the file where you set the base URL to be something different.
+Now, every single mentions in the site will use the base URL defined in the `_config.yml`, _except_ in the file where you set the base URL to be something different.
 
 If you wish to change the base URL for a single mention, but not every mentions in that file, then you'll have to link to the URL the old-fashioned way:
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Hey @benbalter, what do you think of this?
 
 ## Configuration
 
+### Within the `_config.yml`
+
 Have your own social network? No problem. We allow you to configure the base URL of all the mentions.
 
 To change it, add the following to your Jekyll configuration:
@@ -52,7 +54,7 @@ If you're lazy like me, you can use this shorthand:
 jekyll-mentions: https://twitter.com
 ```
 
-An example of Twitter mentions using jekyll-mentions: 
+An example of Twitter mentions using jekyll-mentions:
 
 ```yaml
 plugins:
@@ -60,6 +62,37 @@ plugins:
 
 jekyll-mentions:
   base_url: https://twitter.com
-```  
+```
 
 Et voilà! Your mentions will now use that base URL instead of the default of `https://github.com`.
+
+### Within a page's frontmatter
+
+Now do you want to override the base URL for just a single page/post? No problem. Just set the base URL for that specific page in the frontmatter:
+
+```yaml
+jekyll-mentions:
+  base_url: https://facebook.com
+```
+
+If you're lazy like me, you can use this shorthand:
+
+```yaml
+jekyll-mentions: https://facebook.com
+```
+
+Now, every single mentions in the site will use the base URL defined in the `_config.yml`, EXCEPT in the file where you set the base URL to be something different.
+
+If you wish to change the base URL for a single mentions in a file, but not every mentions in that file, then you'll have to link to the URL the old-fashioned way:
+
+```markdown
+[@benbalter](https://instagram.com/benbalter)
+```
+
+Now, let's say you have a single file where you DON'T want your mentions to become mentionable, AKA you want that to stay plain text. You can do that by specifying `false` in the frontmatter of that file:
+
+```yaml
+jekyll-mentions: false
+```
+
+Now that page/post's mentions will not link to the profiles.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ jekyll-mentions:
   base_url: https://facebook.com
 ```
 
-If you're lazy like me, you can use this shorthand:
+You also can use this shorthand:
 
 ```yaml
 jekyll-mentions: https://facebook.com

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ jekyll-mentions:
 
 Et voilà! Your mentions will now use that base URL instead of the default of `https://github.com`.
 
-### Within a page's frontmatter
+### Within a page's front matter
 
 Now do you want to override the base URL for just a single page/post? No problem. Just set the base URL for that specific page in the frontmatter:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you wish to change the base URL for a single mentions in a file, but not ever
 [@benbalter](https://instagram.com/benbalter)
 ```
 
-Now, let's say you have a single file where you DON'T want your mentions to become mentionable, AKA you want that to stay plain text. You can do that by specifying `false` in the frontmatter of that file:
+Now, let's say you have a single file where you _don't_ want your mentions to become mentionable, AKA you want that to stay plain text. You can do that by specifying `false` in the frontmatter of that file:
 
 ```yaml
 jekyll-mentions: false

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -131,7 +131,7 @@ module Jekyll
         page_reader.read([doc.path]).first.data
       end
 
-      # Private: Finds the current page's config that's normally found in the frontmatter
+      # Private: Finds the current page's config that's normally found in the front matter
       # of the page
       #
       # doc - the current Jekyll::Document

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -18,7 +18,7 @@ module Jekyll
         content = doc.output
         return unless content.include?("@")
 
-        src = mention_base(doc.site.config, doc.data)
+        src = mention_base(doc.site.config.merge(doc.data || {}))
 
         if content.include? BODY_START_TAG
           head, opener, tail  = content.partition(OPENING_BODY_TAG_REGEX)
@@ -58,18 +58,18 @@ module Jekyll
       end
 
       # Public: Calculate the base URL to use for mentioning.
-      # The custom base URL can be defined in either the site config or a
-      # document's front matter as jekyll-mentions.base_url or jekyll-mentions,
-      # and must be a valid URL (i.e. it must include a protocol and valid
-      # domain). It should _not_ have a trailing slash.
       #
-      # site_config - the hash-like configuration of the entire site's config
-      # doc_config - the hash-like configuration of the doc's config
+      # The custom base URL can be defined in either the site config or a document's
+      # front matter as `jekyll-mentions.base_url` or `jekyll-mentions`, and must be
+      # a valid URL (i.e. it must include a protocol and valid domain).
+      # It should _not_ have a trailing slash.
+      #
+      # config - The effective configuration that includes configurations for mentions.
       #
       # Returns a URL to use as the base URL for mentions.
       # Defaults to the https://github.com.
-      def mention_base(site_config, doc_config)
-        mention_config = mention_config(site_config, doc_config)
+      def mention_base(config = {})
+        mention_config = config["jekyll-mentions"]
         case mention_config
         when nil, NilClass
           default_mention_base
@@ -106,10 +106,6 @@ module Jekyll
           rescue TypeError
             %r!@\w+!
           end
-      end
-
-      def mention_config(site_config, doc_config)
-        (site_config || {}).merge(doc_config || {})["jekyll-mentions"]
       end
 
       def default_mention_base

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -7,7 +7,6 @@ module Jekyll
   class Mentions
     GITHUB_DOT_COM = "https://github.com"
     BODY_START_TAG = "<body"
-    JEKYLL_MENTIONS = "jekyll-mentions"
 
     OPENING_BODY_TAG_REGEX = %r!<body(.*?)>\s*!.freeze
 
@@ -115,7 +114,7 @@ module Jekyll
       def mentionable_disabled?(doc)
         page_config = page_config(doc) || {}
         post_config = post_config(doc) || {}
-        page_config.merge(post_config)[JEKYLL_MENTIONS] == false
+        page_config.merge(post_config)["jekyll-mentions"] == false
       end
 
       # Private: Finds the current post's config that's normally found in the front matter
@@ -125,7 +124,7 @@ module Jekyll
       #
       # Returns a hash-like configuration of the current post's config or nil
       def post_config(doc)
-        return unless doc.path.include?("_posts")
+        return unless doc.path.include?("_posts") || doc.path.include?("_drafts")
 
         page_reader = Jekyll::PageReader.new(doc.site, doc.path)
         page_reader.read([doc.path]).first.data
@@ -138,7 +137,7 @@ module Jekyll
       #
       # Returns a hash-like configuration of the current page's config or nil
       def page_config(doc)
-        filtered_pages = doc.site.pages.select { |page| page.name == doc.path.split("/")[-1] }
+        filtered_pages = doc.site.pages.select { |page| page.name == (doc.basename + doc.extname) }
         return unless filtered_pages.size == 1
 
         page = filtered_pages.first
@@ -160,7 +159,7 @@ module Jekyll
         site_config = config[:site_config] || {}
         page_config = config[:page_config] || {}
         post_config = config[:post_config] || {}
-        page_config.merge(post_config)[JEKYLL_MENTIONS] || site_config[JEKYLL_MENTIONS]
+        page_config.merge(post_config)["jekyll-mentions"] || site_config["jekyll-mentions"]
       end
 
       def default_mention_base

--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -106,19 +106,19 @@ module Jekyll
 
       private
 
-      # Private: Returns a boolean indicating whether the frontmatter of a specific doc explicitly
+      # Private: Returns a boolean indicating whether the front matter of a specific doc explicitly
       # disables jekyll-mentions
       #
       # doc - the current Jekyll::Document
       #
-      # Returns true if the frontmatter of the doc sets jekyll-mentions to false, else false
+      # Returns true if the front matter of the doc sets jekyll-mentions to false, else false
       def mentionable_disabled?(doc)
         page_config = page_config(doc) || {}
         post_config = post_config(doc) || {}
         page_config.merge(post_config)[JEKYLL_MENTIONS] == false
       end
 
-      # Private: Finds the current post's config that's normally found in the frontmatter
+      # Private: Finds the current post's config that's normally found in the front matter
       # of the page (this method assumes that your posts are in a `_posts/` directory)
       #
       # doc - the current Jekyll::Document

--- a/spec/fixtures/custom-url-01.md
+++ b/spec/fixtures/custom-url-01.md
@@ -1,0 +1,7 @@
+---
+title: custom URL 01
+jekyll-mentions: https://custom-url.com
+---
+
+test @TestUser test
+> test

--- a/spec/fixtures/custom-url-02.md
+++ b/spec/fixtures/custom-url-02.md
@@ -1,0 +1,8 @@
+---
+title: custom URL 02
+jekyll-mentions:
+  base_url: https://custom-url.com
+---
+
+test @TestUser test
+> test

--- a/spec/fixtures/disabled-mentioning.md
+++ b/spec/fixtures/disabled-mentioning.md
@@ -1,0 +1,7 @@
+---
+title: ignore all mentions
+jekyll-mentions: false
+---
+
+test @TestUser test
+> test

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -123,11 +123,47 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "fetches the custom base from the config" do
-      expect(mentions.mention_base(site.config)).to eql(mentions_src)
+      expect(mentions.mention_base(:site_config => site.config)).to eql(mentions_src)
     end
 
     it "respects the new base when mentionsfying" do
       expect(basic_post.output).to start_with(para(result.sub(default_src, mentions_src)))
+    end
+  end
+
+  context "when the different base is defined in the frontmatter of the page" do
+    let(:mentions_src) { "https://twitter.com" }
+    let(:page_overrides) do
+      {
+        "jekyll-mentions" => { "base_url" => mentions_src },
+      }
+    end
+    let(:config_overrides) do
+      {
+        "jekyll-mentions" => { "base_url" => default_src },
+      }
+    end
+
+    it "fetches the custom base from the config" do
+      expect(mentions.mention_base(:site_config => site.config, :page_config => page_overrides)).to eql(mentions_src)
+    end
+  end
+
+  context "when the different base is defined in the frontmatter of the post" do
+    let(:mentions_src) { "https://twitter.com" }
+    let(:post_overrides) do
+      {
+        "jekyll-mentions" => { "base_url" => mentions_src },
+      }
+    end
+    let(:config_overrides) do
+      {
+        "jekyll-mentions" => { "base_url" => default_src },
+      }
+    end
+
+    it "fetches the custom base from the config" do
+      expect(mentions.mention_base(:site_config => site.config, :post_config => post_overrides)).to eql(mentions_src)
     end
   end
 

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -28,6 +28,11 @@ RSpec.describe(Jekyll::Mentions) do
   let(:doc_with_liquid) { find_by_title(site.collections["docs"].docs, "With Liquid") }
   let(:txt_doc) { find_by_title(site.collections["docs"].docs, "Don't Touch Me") }
   let(:spl_chars_doc) { find_by_title(site.collections["docs"].docs, "Unconventional Names") }
+  let(:index_page) { find_by_title(site.pages, "I'm a page") }
+  let(:minified_page) { find_by_title(site.pages, "I'm minified!") }
+  let(:disabled_mentioning_page) { find_by_title(site.pages, "ignore all mentions") }
+  let(:custom_url_01) { find_by_title(site.pages, "custom URL 01") }
+  let(:custom_url_02) { find_by_title(site.pages, "custom URL 02") }
 
   def para(content)
     "<p>#{content}</p>"
@@ -60,16 +65,16 @@ RSpec.describe(Jekyll::Mentions) do
   end
 
   it "correctly replaces the mentions with the link in pages" do
-    expect(site.pages.first.output).to include(para(result))
+    expect(index_page.output).to include(para(result))
   end
 
   it "correctly replaces the mentions with the link in minified pages" do
-    expect(find_by_title(site.pages, "I'm minified!").output).to include(para(result))
+    expect(minified_page.output).to include(para(result))
   end
 
   it "doesn't mangle layouts" do
-    expect(site.pages.first.output).to include("<html lang=\"en-US\">")
-    expect(site.pages.first.output).to include("<body class=\"wrap\">\n")
+    expect(index_page.output).to include("<html lang=\"en-US\">")
+    expect(index_page.output).to include("<body class=\"wrap\">\n")
   end
 
   it "correctly replaces the mentions with the link in collection documents" do
@@ -84,6 +89,50 @@ RSpec.describe(Jekyll::Mentions) do
     expect(doc_with_liquid.output).to start_with(
       para("#{result} <a href=\"/docs/with_liquid.html\">_docs/with_liquid.md</a>")
     )
+  end
+
+  context "when jekyll-mentions is set to false" do
+    it "should not replace the @TestUser with the link to @TestUser" do
+      expect(disabled_mentioning_page.output).not_to include(result)
+    end
+
+    it "should leave other pages in the site alone and mention as normal" do
+      expect(index_page.output).to include(result)
+    end
+  end
+
+  context "when the jekyll-mentions is overridden on a single file" do
+    let(:custom_url_result) do
+      "<a href=\"https://custom-url.com/TestUser\" class=\"user-mention\">@TestUser</a>"
+    end
+
+    context "when overriden in pattern 'jekyll-mentions: custom_url'" do
+      it "should replace the mentions with the link in that specific file" do
+        expect(custom_url_01.output).to include(custom_url_result)
+      end
+
+      it "should not include the default URL" do
+        expect(custom_url_01.output).not_to include(result)
+      end
+
+      it "should leave other pages in the site alone and mention as normal" do
+        expect(index_page.output).to include(result)
+      end
+    end
+
+    context "when overriden in pattern 'jekyll-mentions.base_url: custom_url'" do
+      it "should replace the mentions with the link in that specific file" do
+        expect(custom_url_02.output).to include(custom_url_result)
+      end
+
+      it "should not include the default URL" do
+        expect(custom_url_02.output).not_to include(result)
+      end
+
+      it "should leave other pages in the site alone and mention as normal" do
+        expect(index_page.output).to include(result)
+      end
+    end
   end
 
   context "with non-word characters" do

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe(Jekyll::Mentions) do
   end
 
   it "has a default source" do
-    expect(mentions.mention_base).to eql(default_src)
+    expect(mentions.mention_base(nil, nil)).to eql(default_src)
   end
 
   it "correctly replaces the mentions with the img in posts" do
@@ -123,7 +123,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "fetches the custom base from the config" do
-      expect(mentions.mention_base(:site_config => site.config)).to eql(mentions_src)
+      expect(mentions.mention_base(site.config, nil)).to eql(mentions_src)
     end
 
     it "respects the new base when mentionsfying" do
@@ -131,9 +131,9 @@ RSpec.describe(Jekyll::Mentions) do
     end
   end
 
-  context "when the different base is defined in the front matter of the page" do
+  context "when the different base is defined in the front matter of the doc" do
     let(:mentions_src) { "https://twitter.com" }
-    let(:page_overrides) do
+    let(:doc_overrides) do
       {
         "jekyll-mentions" => { "base_url" => mentions_src },
       }
@@ -145,25 +145,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "fetches the custom base from the config" do
-      expect(mentions.mention_base(:site_config => site.config, :page_config => page_overrides)).to eql(mentions_src)
-    end
-  end
-
-  context "when the different base is defined in the front matter of the post" do
-    let(:mentions_src) { "https://twitter.com" }
-    let(:post_overrides) do
-      {
-        "jekyll-mentions" => { "base_url" => mentions_src },
-      }
-    end
-    let(:config_overrides) do
-      {
-        "jekyll-mentions" => { "base_url" => default_src },
-      }
-    end
-
-    it "fetches the custom base from the config" do
-      expect(mentions.mention_base(:site_config => site.config, :post_config => post_overrides)).to eql(mentions_src)
+      expect(mentions.mention_base(site.config, doc_overrides)).to eql(mentions_src)
     end
   end
 
@@ -183,7 +165,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "has a default source based on SSL and GITHUB_HOSTNAME" do
-      expect(mentions.mention_base).to eql(default_mention_base)
+      expect(mentions.mention_base(nil, nil)).to eql(default_mention_base)
     end
 
     it "uses correct mention URLs when SSL and GITHUB_HOSTNAME are set" do
@@ -194,12 +176,12 @@ RSpec.describe(Jekyll::Mentions) do
 
     it "falls back to using the default if SSL is empty" do
       ENV["SSL"] = ""
-      expect(mentions.mention_base).to eql(default_src)
+      expect(mentions.mention_base(nil, nil)).to eql(default_src)
     end
 
     it "falls back to using the default if GITHUB_HOSTNAME is empty" do
       ENV["GITHUB_HOSTNAME"] = ""
-      expect(mentions.mention_base).to eql(default_src)
+      expect(mentions.mention_base(nil, nil)).to eql(default_src)
     end
   end
 end

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe(Jekyll::Mentions) do
   end
 
   it "has a default source" do
-    expect(mentions.mention_base(nil, nil)).to eql(default_src)
+    expect(mentions.mention_base).to eql(default_src)
   end
 
   it "correctly replaces the mentions with the img in posts" do
@@ -123,10 +123,10 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "fetches the custom base from the config" do
-      expect(mentions.mention_base(site.config, nil)).to eql(mentions_src)
+      expect(mentions.mention_base(site.config)).to eql(mentions_src)
     end
 
-    it "respects the new base when mentionsfying" do
+    it "respects the new base when mentionifying" do
       expect(basic_post.output).to start_with(para(result.sub(default_src, mentions_src)))
     end
   end
@@ -145,7 +145,8 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "fetches the custom base from the config" do
-      expect(mentions.mention_base(site.config, doc_overrides)).to eql(mentions_src)
+      effective_overrides = site.config.merge(doc_overrides)
+      expect(mentions.mention_base(effective_overrides)).to eql(mentions_src)
     end
   end
 
@@ -165,7 +166,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
 
     it "has a default source based on SSL and GITHUB_HOSTNAME" do
-      expect(mentions.mention_base(nil, nil)).to eql(default_mention_base)
+      expect(mentions.mention_base).to eql(default_mention_base)
     end
 
     it "uses correct mention URLs when SSL and GITHUB_HOSTNAME are set" do
@@ -176,12 +177,12 @@ RSpec.describe(Jekyll::Mentions) do
 
     it "falls back to using the default if SSL is empty" do
       ENV["SSL"] = ""
-      expect(mentions.mention_base(nil, nil)).to eql(default_src)
+      expect(mentions.mention_base).to eql(default_src)
     end
 
     it "falls back to using the default if GITHUB_HOSTNAME is empty" do
       ENV["GITHUB_HOSTNAME"] = ""
-      expect(mentions.mention_base(nil, nil)).to eql(default_src)
+      expect(mentions.mention_base).to eql(default_src)
     end
   end
 end

--- a/spec/mentions_spec.rb
+++ b/spec/mentions_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
   end
 
-  context "when the different base is defined in the frontmatter of the page" do
+  context "when the different base is defined in the front matter of the page" do
     let(:mentions_src) { "https://twitter.com" }
     let(:page_overrides) do
       {
@@ -149,7 +149,7 @@ RSpec.describe(Jekyll::Mentions) do
     end
   end
 
-  context "when the different base is defined in the frontmatter of the post" do
+  context "when the different base is defined in the front matter of the post" do
     let(:mentions_src) { "https://twitter.com" }
     let(:post_overrides) do
       {


### PR DESCRIPTION
Add the ability for the `base_url` to be overridden in a specific file's front matter, instead of using whatever is set in the `_config.yml`. So for a specific file, we can specify a different base URL than whatever is set for the rest of the site in `_config.yml`.

Also let a specific file's front matter to disable @mentions in that file:
```yaml
jekyll-mentions: false
```
---
This change implements a couple of the features that's mentioned in https://github.com/jekyll/jekyll-mentions/issues/39.