### PR TITLE
Incorporate document data only if it has override

### DIFF
--- a/lib/jekyll-mentions.rb
+++ b/lib/jekyll-mentions.rb
@@ -18,7 +18,10 @@ module Jekyll
         content = doc.output
         return unless content.include?("@")
 
-        src = mention_base(doc.site.config.merge(doc.data || {}))
+        config = doc.site.config
+        config = config.merge(doc.data) if doc.data.key?("jekyll-mentions")
+
+        src = mention_base(config)
 
         if content.include? BODY_START_TAG
           head, opener, tail  = content.partition(OPENING_BODY_TAG_REGEX)


### PR DESCRIPTION
Currently on `master`, `doc.site.config` gets duplicated for every `doc` that gets *mentionified*.
This can  be limited by duplicating the site config for only those `doc` objects that have the key `jekyll-mentions` in their front matter.